### PR TITLE
Add support for tokens as environment variables

### DIFF
--- a/Chat.mjs
+++ b/Chat.mjs
@@ -136,6 +136,21 @@ export function chat(model) {
   }
 }
 
+export async function checkForToken(model) {
+  model = MODELS[model] || model;
+  if (model.startsWith('gpt')) {
+    await getToken('openai');
+  } else if (model.startsWith('claude')) {
+    await getToken('anthropic');
+  } else if (model.startsWith('llama')) {
+    await getToken('groq');
+  } else if (model.startsWith('gemini')) {
+    await getToken('google');
+  } else {
+    throw new Error(`Unsupported model: ${model}`);
+  }
+}
+
 // Utility function to read the API token for a given vendor
 async function getToken(vendor) {
   const tokenPath = path.join(os.homedir(), '.config', `${vendor}.token`);
@@ -145,7 +160,6 @@ async function getToken(vendor) {
   } catch (err) {
     // If the file is not found, check for the token in the environment variable
     if (err.message.includes('ENOENT')) {
-      console.log(`Checking for ${vendor} API key in environment variable...`);
       switch (vendor) {
         case 'openai':
           const token = process.env.OPENAI_API_KEY;

--- a/Chat.mjs
+++ b/Chat.mjs
@@ -164,7 +164,7 @@ async function getToken(vendor) {
         case 'openai':
           const token = process.env.OPENAI_API_KEY;
           if (token === undefined) {
-            console.error('Environment variable OPENAI_API_KEY is not set');
+            console.error(`API key for ${vendor} not found in environment variable or ${tokenPath}`);
             process.exit(1);
           }
           return token;

--- a/chatsh.mjs
+++ b/chatsh.mjs
@@ -3,7 +3,7 @@
 import readline from 'readline';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { chat, MODELS } from './Chat.mjs';
+import { chat, MODELS, checkForToken } from './Chat.mjs';
 
 const execAsync = promisify(exec);
 
@@ -54,6 +54,9 @@ async function prompt(query) {
 
 // Main interaction loop
 async function main() {
+  // Check for existing token before starting
+  await checkForToken(MODEL);
+
   let lastOutput = "";
   
   while (true) {


### PR DESCRIPTION
If token files not found in `.config` checks for tokens defined in environment variables.  Currently just handles OpenAI tokens.

Also checks for existence of token before starting chat.