### PR TITLE
Tscoder

### DIFF
--- a/TS_GUIDE_AI.md
+++ b/TS_GUIDE_AI.md
@@ -1,0 +1,60 @@
+# GUIDE FOR THE TYPESCRIPT LANGUAGE
+
+Here we need to the describe the set of typescript we will be using (only functional). and examples of the structure of the code (since well use the kind2 dir and file structure);
+
+# TypeScript project structure
+
+Since the subset of typescript described above is simple, we will use the following pattern.o
+
+### Top-Level Function
+
+Every .ts file must define ONE top-level function:
+
+```
+function (arg0: typ0, arg1: typ1): ret_type {
+  body
+}
+```
+
+Where:
+- arg0, arg1... are the function arguments
+- ret_typ is the returned type
+- body is the function's body
+
+
+### Top-Level Datatype
+
+Alternatively, a .ts file can also define a datatype:
+
+```
+type Action
+  = { f0c1: t0c1, f1c1: t1c1 }
+  | { f0c2: t0c2, f1c2: t1c2 }
+```
+
+Where:
+- f0c1, f1c1... are fields of the first constructor
+- t0c1, t1c1... are types of the fields
+- f0c2, f1c2... are fields of the second constructor
+- t0c2, t1c2... are types of the fields
+
+### Names, Paths
+
+TODO
+
+
+## TypeScript UwU Moba Examples
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,55 @@
+# How to configure AI-scripts 
+
+To install all the scripts globally in your machine, simply:
+
+`cd` untill you reach `AI-scripts` dir.
+Run `npm install -g .`
+
+Now you should be able to run any of the scripts specified on `package.json` `bin` section globally.
+
+# How to configure refactor on vim
+
+This is a vim configuration to use Kindcoder and Tscoder.
+
+## Kindcoder, Tscoder and Refactor
+
+```
+" Refactors the file using AI
+function! RefactorFile()
+  let l:current_file = expand('%:p')
+  call inputsave()
+  let l:user_text = input('Enter refactor request: ')
+  call inputrestore()
+  
+  " Save the file before refactoring
+  write
+
+  if expand('%:e') == 'kind2'
+    let l:cmd = 'kindcoder "' . l:current_file . '" "' . l:user_text . '" s'
+  elseif expand('%:e') == 'ts'
+    let l:cmd = 'tscoder "' . l:current_file . '" "' . l:user_text . '" s'
+  else
+    let l:cmd = 'refactor "' . l:current_file . '" "' . l:user_text . '" s'
+  endif
+  
+  " Add --check flag if user_text starts with '-' or is empty
+  if l:user_text =~ '^-' || empty(l:user_text)
+    let l:cmd .= ' --check'
+  endif
+  
+  execute '!clear && ' . l:cmd
+  edit!
+endfunction
+
+nnoremap <space> :call RefactorFile()<CR>
+```
+
+This snippet basically remaps pressing space in normal mode to call the refactor file function.
+Assuming you have kindcoder and tscoder installed, it will:
+
+- If the file is a .kind2 file, calls kindcoder to it.
+- If it is a .ts file, use the tscoder on it
+- Else, call the normal refactor command agnostic of language.
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,17 @@
         "groq-sdk": "^0.3.2",
         "openai": "^4.31.0",
         "portkey-ai": "^1.3.0",
-        "punycode": "^2.3.1"
+        "punycode": "^2.3.1",
+        "typescript": "^5.5.4"
       },
       "bin": {
         "aiemu": "aiemu.mjs",
         "chatsh": "chatsh.mjs",
-        "holefill": "holefill.mjs"
+        "csh": "chatsh.mjs",
+        "holefill": "holefill.mjs",
+        "kindcoder": "kindcoder.mjs",
+        "refactor": "refactor.mjs",
+        "ts-deps": "ts-deps.mjs"
       },
       "devDependencies": {
         "tsx": "^4.16.2"
@@ -1038,6 +1043,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "refactor": "refactor.mjs",
     "kindcoder": "kindcoder.mjs",
     "aiemu": "aiemu.mjs",
-    "ts-deps": "ts-deps.mjs"
+    "ts-deps": "ts-deps.mjs",
+    "tscoder": "tscoder.mjs"
   },
   "scripts": {},
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "groq-sdk": "^0.3.2",
     "openai": "^4.31.0",
     "portkey-ai": "^1.3.0",
-    "punycode": "^2.3.1"
+    "punycode": "^2.3.1",
+    "typescript": "^5.5.4"
   },
   "devDependencies": {
     "tsx": "^4.16.2"

--- a/ts-deps.mjs
+++ b/ts-deps.mjs
@@ -75,7 +75,7 @@ function main() {
 
   if (dependencies.size > 0) {
     for (const [source, imported] of dependencies) {
-      console.log(`${source}/${imported}`);
+      console.log(`${source}/{${imported}}`);
     }
   } else {
     console.log('No dependencies found.');

--- a/ts-deps.mjs
+++ b/ts-deps.mjs
@@ -66,7 +66,7 @@ function extractDependencies(filePath) {
 function main() {
   const args = process.argv.slice(2);
   if (args.length !== 1) {
-    console.error('Usage: node script.js <file.ts>');
+    console.error('Usage: ts-deps <file.ts>');
     process.exit(1);
   }
 

--- a/ts-deps.mjs
+++ b/ts-deps.mjs
@@ -2,50 +2,81 @@
 
 import fs from 'fs';
 import path from 'path';
+import ts from 'typescript';
 
 function extractDependencies(filePath) {
   try {
     const content = fs.readFileSync(filePath, 'utf8');
-    const lines = content.split('\n');
-    const dependencies = [];
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      content,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
-    for (const line of lines) {
-      const trimmedLine = line.trim();
-      if (!trimmedLine.startsWith('import')) {
-        break;
-      }
+    const dependencies = new Map();
 
-      const match = trimmedLine.match(/import\s+(?:{([^}]+)}|(\w+))\s+from\s+['"]([^'"]+)['"]/);
-      if (match) {
-        const [, namedImports, defaultImport, modulePath] = match;
-        if (namedImports) {
-          const importList = namedImports.split(',').map(i => i.trim());
-          dependencies.push(`${modulePath}/{${importList.join(', ')}}`);
-        } else if (defaultImport) {
-          dependencies.push(`${modulePath}/{${defaultImport}}`);
+    function visit(node) {
+      if (ts.isImportDeclaration(node)) {
+        const moduleSpecifier = node.moduleSpecifier.text;
+        const importClause = node.importClause;
+        if (importClause) {
+          if (importClause.name) {
+            dependencies.set(moduleSpecifier, importClause.name.text);
+          } else if (importClause.namedBindings) {
+            if (ts.isNamedImports(importClause.namedBindings)) {
+              const imports = importClause.namedBindings.elements.map(e => e.name.text);
+              dependencies.set(moduleSpecifier, `{${imports.join(', ')}}`);
+            } else if (ts.isNamespaceImport(importClause.namedBindings)) {
+              dependencies.set(moduleSpecifier, `* as ${importClause.namedBindings.name.text}`);
+            }
+          }
+        } else {
+          dependencies.set(moduleSpecifier, '');
+        }
+      } else if (ts.isImportEqualsDeclaration(node)) {
+        if (ts.isExternalModuleReference(node.moduleReference)) {
+          const moduleSpecifier = node.moduleReference.expression.text;
+          dependencies.set(moduleSpecifier, node.name.text);
+        }
+      } else if (ts.isCallExpression(node) && node.expression.text === 'require') {
+        if (node.arguments.length > 0 && ts.isStringLiteral(node.arguments[0])) {
+          const moduleSpecifier = node.arguments[0].text;
+          dependencies.set(moduleSpecifier, '');
+        }
+      } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        if (node.arguments.length > 0 && ts.isStringLiteral(node.arguments[0])) {
+          const moduleSpecifier = node.arguments[0].text;
+          dependencies.set(moduleSpecifier, '');
         }
       }
+
+      ts.forEachChild(node, visit);
     }
+
+    visit(sourceFile);
 
     return dependencies;
   } catch (error) {
-    console.error(`Error reading file: ${error.message}`);
-    return [];
+    console.error(`Error processing file: ${error.message}`);
+    return new Map();
   }
 }
 
 function main() {
   const args = process.argv.slice(2);
   if (args.length !== 1) {
-    console.error('Usage: node ts-deps.mjs <file.ts>');
+    console.error('Usage: node script.js <file.ts>');
     process.exit(1);
   }
 
   const filePath = args[0];
   const dependencies = extractDependencies(filePath);
 
-  if (dependencies.length > 0) {
-    dependencies.forEach(dep => console.log(`${dep}`));
+  if (dependencies.size > 0) {
+    for (const [source, imported] of dependencies) {
+      console.log(`${source}/${imported}`);
+    }
   } else {
     console.log('No dependencies found.');
   }

--- a/tscoder.mjs
+++ b/tscoder.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import process from "process";
+import { chat, MODELS, tokenCount } from './Chat.mjs';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+const ts_guide = await fs.readFile(new URL('./TS_GUIDE_AI.md', import.meta.url), 'utf-8');
+
+// System prompt for the AI model, defining its role and behavior
+// TODO add tsCoder and DepsPrediction text
+const system_TsCoder = `
+You are TsCoder, a TypeScript language coding assistant.
+
+# USER INPUT
+
+You will receive:
+
+1. A target <FILE/> in the TypeScript language. That's the code you must update.
+
+2. The user's change <REQUEST/>. You must perform that change on the target file.
+
+3. Some additional context (files, dirs) that could be helpful.
+
+# TSCODER OUTPUT
+
+You, TsCoder, must answer with a single <RESULT/> tag, which must include the user's file, except *modified* to fulfill the user's request, and nothing else.
+
+# GUIDE FOR REFACTORING
+
+1. Make ONLY the changes necessary to correctly fullfill the user's REQUEST.
+2. Do NOT fix, remove, complete or alter any parts unrelated to the REQUEST.
+3. Preserve the same indentation and style of the target FILE.
+4. Consulte TypeScript guide to emit syntactically correct code.
+5. Be precise and careful in your modifications.
+
+${ts_guide}
+
+# TSCODER EXAMPLE
+
+Below is a complete example of how TsCoder should interact with the user.
+
+## User:
+
+<FILE path="/Users/v/vic/dev/ts/book/Nat/_.ts">
+`.trim();
+const system_DepsPredictor = "".trim();
+
+// Function to predict dependencies
+async function predictDependencies(name, fileContent) {
+  // Function to get all Typescript files recursively
+  async function getAllTsFiles(dir) {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const files = await Promise.all(entries.map(async (entry) => {
+      const res = path.resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        const subFiles = await getAllTsFiles(res);
+        return subFiles.length > 0 ? { name: entry.name, children: subFiles } : null;
+      } else if (entry.name.endsWith('.ts')) {
+        return { name: entry.name.replace('.ts', '') };
+      }
+      return null;
+    }));
+    return files.filter(file => file !== null).map(file => ({...file, name: file.name.replace(/\/_$/, '')}));
+  }
+
+  // Function to build a tree structure from files
+  function buildTree(files, prefix = '') {
+    let result = '';
+    for (const file of files) {
+      if (file.children) {
+        result += `${prefix}- ${file.name}/\n`;
+        result += buildTree(file.children, `${prefix}  `);
+      } else {
+        result += `${prefix}- ${file.name}\n`;
+      }
+    }
+    return result;
+  }
+
+  const allFiles = await getAllTsFiles("./");
+  const defsTree = buildTree(allFiles);
+
+  const aiInput = [
+    `<NAME>${name}</NAME>`,
+    '<SOURCE>',
+    fileContent.trim(),
+    '</SOURCE>',
+    '<DEFINITIONS>',
+    defsTree.trim(),
+    '</DEFINITIONS>'
+  ].join('\n').trim();
+
+  const aiOutput = await chat("s")(aiInput, { system: system_DepsPredictor, model: "s" });
+  console.log("");
+
+  const dependenciesMatch = aiOutput.match(/<DEPENDENCIES>([\s\S]*)<\/DEPENDENCIES>/);
+  if (!dependenciesMatch) {
+    console.error("Error: AI output does not contain a valid DEPENDENCIES tag.");
+    return [];
+  }
+
+  return dependenciesMatch[1].trim().split('\n').map(dep => dep.trim());
+}
+
+// Function to perform type checking based on file extension
+async function typeCheck(file) {
+  let ext = path.extname(file);
+  let cmd = `tsc ${file}`;
+  try {
+    var result = await execAsync(cmd);
+    return result.stderr.trim() || result.stdout.trim();
+  } catch (error) {
+    return error.stderr.trim();
+  }
+}
+
+// Main function to handle the refactoring process
+async function main() {
+  // Check for correct usage and parse command-line arguments
+  if (process.argv.length < 3) {
+    console.log("Usage: tscoder <file> <request> [<model>]");
+    process.exit(1);
+  }
+
+  let file = process.argv[2];
+  let request = process.argv[3];
+  let model = process.argv[4] || "s";
+
+  // Initialize the chat function with the specified model
+  let ask = chat(model);
+
+  // Get directory and file information
+  let dir = path.dirname(file);
+  let fileContent;
+  try {
+    fileContent = await fs.readFile(file, 'utf-8');
+  } catch (e) {
+    fileContent = "";
+  }
+  let dirContent = await fs.readdir(dir);
+
+  // If the request is empty, replace it by a default request.
+  // TODO enhance default request
+  if (request.trim() === '') {
+    request = [
+      "Update this file.",
+      "- If it is empty, implement an initial template.",
+      "- If it has holes, fill them, up to \"one layer\".",
+      "- If it has no holes, fully complete it, as much as possible."
+    ].join('\n');
+  }
+
+  // If the file is empty, ask the AI to fill with an initial template
+  // TODO: add default def for ts template
+  if (fileContent.trim() === '') {
+    fileContent = [
+      "",
+    ].join('\n');
+  }
+
+  // Extract the definition name from the file path
+  // TODO: probably change here to use smth other than book/
+  let defName = file.split('/book/')[1].replace('.ts', '');
+
+  // Collect direct and indirect dependencies
+  let deps;
+  try {
+    // this assumes the ts-deps command from here is installed
+    let { stdout } = await execAsync(`ts-deps ${defName}`);
+    deps = stdout.trim().split('\n');
+  } catch (e) {
+    deps = [];
+  }
+
+  // Predict additional dependencies
+  const predictedDeps = await predictDependencies(defName, fileContent);
+
+  deps = [...new Set([...deps, ...predictedDeps])];
+  deps = deps.filter(dep => dep !== defName);
+
+  // Read dependent files
+  let depFiles = await Promise.all(deps.map(async (dep) => {
+    let depPath, content;
+    let path0 = path.join(dir, '..', `${dep}.ts`);
+    // TODO: _.ts not needed probably?
+    let path1 = path.join(dir, '..', `${dep}/_.ts`); 
+    try {
+      content = await fs.readFile(path0, 'utf-8');
+      depPath = path0;
+    } catch (error) {
+      try {
+        content = await fs.readFile(path1, 'utf-8');
+        depPath = path1;
+      } catch (error) {
+        return "";
+      }
+    }
+    return `<FILE path="${depPath}">\n${content}\n</FILE>`;
+  }));
+
+  // Perform initial type checking
+  let initialCheck = (await typeCheck(defName)).replace(/\x1b\[[0-9;]*m/g, '');
+
+  // Prepare AI input
+  let aiInput = [
+    ...depFiles,
+    `<FILE path="${file}" target>`,
+    fileContent,
+    '</FILE>',
+    '<CHECKER>',
+    initialCheck,
+    '</CHECKER>',
+    '<REQUEST>',
+    request,
+    '</REQUEST>'
+  ].join('\n').trim();
+
+  // Write a .prompt file with the system + aiInput strings
+  await fs.writeFile('.tscoder', system_TsCoder + '\n\n' + aiInput, 'utf-8');
+
+  // Call the AI model
+  let aiOutput = await ask(aiInput, { system: system_TsCoder, model });
+  console.log("");
+
+  // Extract the result from AI output
+  let resultMatch = aiOutput.match(/<RESULT>([\s\S]*)<\/RESULT>/);
+  if (!resultMatch) {
+    console.error("Error: AI output does not contain a valid RESULT tag.");
+    process.exit(1);
+  }
+
+  let result = resultMatch[1].trim();
+
+  // Write the result back to the file
+  await fs.writeFile(file, result, 'utf-8');
+
+  console.log("File updated successfully.");
+}
+
+// Run the main function and handle any errors
+main().catch(console.error);
+

--- a/tscoder.mjs
+++ b/tscoder.mjs
@@ -163,19 +163,23 @@ async function main() {
     ].join('\n');
   }
 
+  console.log(file);
+
   // Extract the definition name from the file path
   // TODO: probably change here to use smth other than book/
-  let defName = file.split('/book/')[1].replace('.ts', '');
+  // TODO: fix ts-deps to see defs without .ts
+  let defName = file.replace('.ts', '');
+  console.log(defName);
 
   // Collect direct and indirect dependencies
   let deps;
   try {
-    // this assumes the ts-deps command from here is installed
-    let { stdout } = await execAsync(`ts-deps ${defName}`);
+    let { stdout } = await execAsync(`ts-deps ${file}`);
     deps = stdout.trim().split('\n');
   } catch (e) {
     deps = [];
   }
+
 
   // Predict additional dependencies
   const predictedDeps = await predictDependencies(defName, fileContent);
@@ -187,7 +191,6 @@ async function main() {
   let depFiles = await Promise.all(deps.map(async (dep) => {
     let depPath, content;
     let path0 = path.join(dir, '..', `${dep}.ts`);
-    // TODO: _.ts not needed probably?
     let path1 = path.join(dir, '..', `${dep}/_.ts`); 
     try {
       content = await fs.readFile(path0, 'utf-8');

--- a/tscoder.mjs
+++ b/tscoder.mjs
@@ -46,8 +46,60 @@ Below is a complete example of how TsCoder should interact with the user.
 
 ## User:
 
-<FILE path="/Users/v/vic/dev/ts/book/Nat/_.ts">
-`.trim();
+<FILE path="/Users/v/vic/dev/ts/book/Pair/_.ts">
+...
+</FILE>
+
+<FILE path="/Users/v/vic/dev/ts/book/Pair/fst.ts">
+...
+</FILE>
+
+<FILE path="/Users/v/vic/dev/ts/book/Pair/snd.ts">
+...
+</FILE>
+
+<FILE path="/Users/v/vic/dev/ts/book/Pair/internal_product.ts" target>
+import { Pair } from "./_";
+import { fst } from "./fst";
+import { snd } from "./snd";
+
+export function internal_product(p: Pair<number, number>): number {
+?
+}
+...
+</FILE>
+
+<REQUEST>
+return the first element times the second element
+</REQUEST>
+
+<RESULT>
+import { Pair } from "./_";
+import { fst } from "./fst";
+import { snd } from "./snd";
+
+export function internal_product(p: Pair<number, number>): number {
+  return fst<number, number>(p) * snd<number, number>(p);
+}
+</RESULT>
+
+# EXPLANATION
+
+## Input:
+
+The user provided a target file (Pair/internal_product) to be modified, and a request:
+"return the first element times the second element". The user also provided some additional files and dirs for
+context (including Pair, Pair/fst, Pair/snd). The target file had an incomplete
+top-level definition, 'internal_product', with a hole, '?', as its body.
+
+## Output:
+
+As a response, you, TsCoder, used the imported fst and snd functions and returned the first element of the pair times the second element of the pair. You did NOT perform any extra work, nor change anything beyond what the user explicitly asked for. Instead, you just returned the result needed. You included the updated file inside a RESULT tag, completing the task successfully. Good job!
+
+# Task
+
+The user will now give you a TypeScript file, and a change request. Read it carefully and update is as demanded. Consult the guides above as necessary. Pay attention to syntax details, like parenthesis, style guide, to emit valid code. Do it now:`.trim();
+
 const system_DepsPredictor = "".trim();
 
 // Function to predict dependencies
@@ -159,15 +211,34 @@ async function main() {
   // TODO: add default def for ts template
   if (fileContent.trim() === '') {
     fileContent = [
+      "This file is empty. Please replace it with a TypeScript definition. Example:",
       "",
+      "/// Does foo.",
+      "///",
+      "/// # Input",
+      "///",
+      "/// * `x0` - Description",
+      "/// * `x1` - Description",
+      "/// ...",
+      "///",
+      "/// # Output",
+      "///",
+      "/// The result of doing foo",
+      "import { a, b } from './Lib/A';",
+      "import { c, d } from './Lib/B';",
+      "...",
+      "",
+      "function foo<A, B> (x0: X0, x1: X1)
+      "...",
+      "",
+      "body",
+      "```",
     ].join('\n');
   }
 
   console.log(file);
 
   // Extract the definition name from the file path
-  // TODO: probably change here to use smth other than book/
-  // TODO: fix ts-deps to see defs without .ts
   let defName = file.replace('.ts', '');
   console.log(defName);
 
@@ -179,7 +250,6 @@ async function main() {
   } catch (e) {
     deps = [];
   }
-
 
   // Predict additional dependencies
   const predictedDeps = await predictDependencies(defName, fileContent);


### PR DESCRIPTION
Tscoder and ts-dependencies

Implement the equivalent of kindcoder to typescript.

Ts-deps support:

`import { a } from b;` works
`import a from b;` works
`const a = require("b")` works, etc

Also writes a `tscoder` based on the old kindcoder but adjusted for typescript (but using the same file structure).

Also a simple .md on how to install and run using vim.